### PR TITLE
Fixed a bug with upvoting ratios

### DIFF
--- a/sosBot.py
+++ b/sosBot.py
@@ -119,7 +119,7 @@ async def on_message(message):
   
   #ratio time
   #message.author.id
-  if 'ratio' in message.content:
+  if 'ratio' in message.content.split():
     await message.add_reaction('<:upvote:844410038256795678>')
 
   #valorant unrated composition maker


### PR DESCRIPTION
The bot should no longer upvote words that contain the string "ratio" (ex: irrational, celebration)